### PR TITLE
Wrapped ZBX_ACTIVE_ALLOW in quotes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     ports:
       - "10050:10050"
     environment:
-      ZBX_ACTIVE_ALLOW: false
+      ZBX_ACTIVE_ALLOW: "false"
       TZ: ${TZ}
       ZBX_SERVER_HOST: zabbix-server
       ZBX_SERVER_PORT: 10051


### PR DESCRIPTION
Wrapped services.zabbix-agent.environment.ZBX_ACTIVE_ALLOW in quotes to ensure it is treated as a valid string.